### PR TITLE
change animated from 200 to 500

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var HoverCarousel = function HoverCarousel(_ref) {
       animated = setTimeout(function () {
         wrap.css("scroll-behavior", "auto");
         animated = null;
-      }, 200);
+      }, 500);
     };
     var onMouseMove = function onMouseMove(e) {
       if (animated) return;


### PR DESCRIPTION
I noticed that the animation would "snap" at onMouseEnter despite onMouseMove attempting to prevent this from happening. The "animated" time is set for 200, and the transition is also set to "0.2s ease", yet the animation would still snap.  This could be due to:

- Multiple large image files
- User hardware limitations
- CSS & JavaScript timing not in sync

I experimented with different timeouts and found 500 to provide noticeably fewer "snaps" without creating a noticeable delay to the smooth scroll.